### PR TITLE
JDT Spelling is the plugin name

### DIFF
--- a/plugins/jdt.spelling/plugin.xml
+++ b/plugins/jdt.spelling/plugin.xml
@@ -66,7 +66,7 @@
             category="org.eclipse.jdt.ui.preferences.JavaBasePreferencePage"
             class="jdt.spelling.preferences.SpellingPreferencePage"
             id="jdt.spelling.preferences.SpellingPreferencePage"
-            name="Java type spelling">
+            name="JDT Spelling">
       </page>
    </extension>
    <extension


### PR DESCRIPTION
Having other name in preferences makes it look like standard Eclipse feature, while JDT Spelling prefs are missing
