### PR TITLE
CamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ jdt.spelling
 Spelling for Java names using JDT.
 
 The aim is to provide spelling support for words contained in the names of Java artifacts: Interfaces, Classes, Methods, ...
-Splitting out the names using regular naming patters for Java names.
+Splitting out the names using regular naming patters for Java names, that is usually CamelCase for classes and variable, and connecting with '.' for package names.
 
 This relies heavily on org.eclipse.jdt, and currently uses internal components.
 


### PR DESCRIPTION
as side effect underline_concatenated_names are also underlined (as having spelling error)

This make this plugin closer to code style checking
