### PR TITLE
TODO: add link to General Preferences

### DIFF
--- a/plugins/jdt.spelling/src/jdt/spelling/preferences/SpellingPreferencePage.java
+++ b/plugins/jdt.spelling/src/jdt/spelling/preferences/SpellingPreferencePage.java
@@ -124,7 +124,7 @@ public class SpellingPreferencePage extends PreferencePage implements IWorkbench
 		link.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
 				IWorkbenchPreferenceContainer container= (IWorkbenchPreferenceContainer) getContainer();
-				container.openPage("org.eclipse.ui.preferencePages.GeneralTextEditor", null);
+				container.openPage("org.eclipse.ui.editors.preferencePages.Spelling", null);
 			}
 		});		
 


### PR DESCRIPTION
currently links to "org.eclipse.ui.preferencePages.GeneralTextEditor",  
I don't know yet how to references General -> Editors -> Text Editors -> Spelling
